### PR TITLE
[TSK-38] 인생네컷 챌린지

### DIFF
--- a/src/main/java/ongjong/namanmoo/controller/ChallengeController.java
+++ b/src/main/java/ongjong/namanmoo/controller/ChallengeController.java
@@ -193,9 +193,6 @@ public class ChallengeController {
                     .body(new ApiResponse<>("404", "Challenge not found for the provided challengeId", null));
         }
 
-        // 현재 진행 번호 조회
-        Long currentNum = challengeService.findCurrentNum(challengeId);
-
         // 멤버와 챌린지를 통해 timestamp 조회
         Long timestamp = answerService.findDateByChallengeMember(challenge);
 

--- a/src/main/java/ongjong/namanmoo/controller/ChallengeController.java
+++ b/src/main/java/ongjong/namanmoo/controller/ChallengeController.java
@@ -6,16 +6,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import ongjong.namanmoo.domain.Family;
+import ongjong.namanmoo.dto.challenge.*;
 import ongjong.namanmoo.global.security.util.DateUtil;
 import ongjong.namanmoo.domain.Member;
 import ongjong.namanmoo.domain.answer.Answer;
 import ongjong.namanmoo.domain.challenge.Challenge;
 import ongjong.namanmoo.dto.answer.ModifyAnswerDto;
-import ongjong.namanmoo.dto.challenge.ChallengeDto;
-import ongjong.namanmoo.dto.challenge.ChallengeListDto;
-import ongjong.namanmoo.dto.challenge.NormalChallengeDto;
-import ongjong.namanmoo.dto.challenge.PhotoChallengeDto;
-import ongjong.namanmoo.repository.AnswerRepository;
 import ongjong.namanmoo.response.ApiResponse;
 import ongjong.namanmoo.service.*;
 import org.springframework.http.HttpStatus;
@@ -163,17 +160,14 @@ public class ChallengeController {
 
         // S3에 파일 업로드
         String uploadImageUrl = awsS3Service.uploadFile(answerFile);
-        log.debug("Uploaded image URL: {}", uploadImageUrl);
 
         // Answer 객체 수정 및 저장
         Optional<Answer> optionalAnswer = answerService.findAnswerByChallengeAndMember(challenge, member);
         if (optionalAnswer.isPresent()) {
             Answer answer = optionalAnswer.get();
-            log.debug("Answer found: {}", answer);
             answer.setAnswerContent(uploadImageUrl);
             answer.setModifiedDate(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm:ss")));
             answerService.saveAnswer(answer);
-            log.debug("Answer saved: {}", answer);
 
             // Map 형태로 답변 URL 반환
             Map<String, String> responseData = new HashMap<>();
@@ -189,22 +183,32 @@ public class ChallengeController {
 
     // 화상 통화 챌린지 조회
     @GetMapping("/face")
-    public ResponseEntity<ApiResponse<ChallengeDto>> getFaceChallenge(
+    public ResponseEntity<ApiResponse<Object>> getFaceChallenge(
             @RequestParam("challengeId") Long challengeId) throws Exception {
 
+        // 챌린지 조회
         Challenge challenge = challengeService.findChallengeById(challengeId);
         if (challenge == null) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
                     .body(new ApiResponse<>("404", "Challenge not found for the provided challengeId", null));
         }
 
-        // 챌린지 번호를 가져옴 (예를 들어, 해당 챌린지의 현재 진행 번호)
+        // 현재 진행 번호 조회
         Long currentNum = challengeService.findCurrentNum(challengeId);
-        // 챌린지와 멤버를 통해 timestamp를 가져옴
+
+        // 멤버와 챌린지를 통해 timestamp 조회
         Long timestamp = answerService.findDateByChallengeMember(challenge);
 
-        // 화상 통화 챌린지 정보 가져오기
-        ChallengeDto challengeDto = new ChallengeDto(challenge, currentNum, timestamp.toString());
+        // 가족 초대 코드 조회 (멤버를 통해 가족 정보를 가져온 후 초대 코드 획득)
+        Member member = memberService.findMemberByLoginId();
+        Family family = member.getFamily();
+        String inviteCode = family != null ? family.getInviteCode() : null;
+
+        // isComplete 계산 로직
+        boolean isComplete = answerService.findIsCompleteAnswer(challenge, member);
+
+        // 화상 통화 챌린지 정보 DTO 생성
+        FaceChallengeDto challengeDto = new FaceChallengeDto(challenge, timestamp, isComplete, inviteCode);
 
         return ResponseEntity.ok(new ApiResponse<>("200", "Success", challengeDto));
     }

--- a/src/main/java/ongjong/namanmoo/controller/ChallengeController.java
+++ b/src/main/java/ongjong/namanmoo/controller/ChallengeController.java
@@ -145,13 +145,8 @@ public class ChallengeController {
     // 사진 챌린지 수정
     @PostMapping("/photo")
     public ResponseEntity<ApiResponse<Map<String, String>>> savePhotoAnswer(
-            @ModelAttribute PhotoAnswerRequest photoAnswerRequest) throws Exception {
-//            @RequestPart("challengeId") Long challengeId,
-//            @RequestPart("answer") MultipartFile answerFile) throws Exception {
-        log.debug("PhotoAnswerRequest received: {}", photoAnswerRequest);
-
-        Long challengeId = photoAnswerRequest.getChallengeId();
-        MultipartFile answerFile = photoAnswerRequest.getAnswer();
+            @RequestPart("challengeId") Long challengeId,
+            @RequestPart("answer") MultipartFile answerFile) throws Exception {
 
         Member member = memberService.findMemberByLoginId();
         Challenge challenge = challengeService.findChallengeById(challengeId);

--- a/src/main/java/ongjong/namanmoo/controller/MemberController.java
+++ b/src/main/java/ongjong/namanmoo/controller/MemberController.java
@@ -60,23 +60,8 @@ public class MemberController {
     @ResponseStatus(HttpStatus.OK)
     public ApiResponse<MemberInfoDto> updateBasicInfo(@RequestPart("userInfo") MemberUpdateDto memberUpdateDto,
                                                       @RequestPart("userImg") Optional<MultipartFile> userImg) throws Exception {
-
-        log.info("Received MemberUpdateDto: {}", memberUpdateDto);
-        log.info("Received MultipartFile: {}", userImg);
-
-        // 파일을 전송했을 경우에만 S3 파일 업로드 수행
-        if (userImg.isPresent() && !userImg.get().isEmpty()) {
-            log.debug("Uploading file to S3...");
-            String uploadImageUrl = awsS3Service.uploadFile(userImg.get());
-            log.debug("File uploaded to S3: {}", uploadImageUrl);
-        }
-
-        log.debug("Updating member information...");
         memberService.update(memberUpdateDto, userImg);
-        log.debug("Member information updated.");
-
         MemberInfoDto info = memberService.getMyInfo();
-        log.debug("Member info retrieved: {}", info);
         return new ApiResponse<>("200", "Update User Info Success", info);
     }
 

--- a/src/main/java/ongjong/namanmoo/dto/challenge/FaceChallengeDto.java
+++ b/src/main/java/ongjong/namanmoo/dto/challenge/FaceChallengeDto.java
@@ -10,22 +10,17 @@ import java.util.stream.Collectors;
 
 @Data
 public class FaceChallengeDto {
-
     private String challengeTitle;
     private String challengeNumber;
     private Long challengeDate;
     private boolean isComplete;
-    private List<AnswerDto> answerList;
+    private String code;
 
-    public FaceChallengeDto(Challenge challenge, boolean isComplete, Long timeStamp , List<Answer> answers) {
+    public FaceChallengeDto(Challenge challenge, Long timeStamp, boolean isComplete, String inviteCode) {
         this.challengeTitle = challenge.getChallengeTitle();
         this.challengeNumber = challenge.getChallengeNum().toString();
-        this.challengeDate = timeStamp; // Use actual challenge date if available
+        this.challengeDate = timeStamp;
         this.isComplete = isComplete;
-        this.answerList = answers.stream()
-                .map(AnswerDto::new)
-                .collect(Collectors.toList());
+        this.code = inviteCode;
     }
-
-    private List<AnswerDto> answerDto;
 }

--- a/src/main/java/ongjong/namanmoo/dto/challenge/FaceChallengeDto.java
+++ b/src/main/java/ongjong/namanmoo/dto/challenge/FaceChallengeDto.java
@@ -10,6 +10,7 @@ import java.util.stream.Collectors;
 
 @Data
 public class FaceChallengeDto {
+
     private String challengeTitle;
     private String challengeNumber;
     private Long challengeDate;

--- a/src/main/java/ongjong/namanmoo/dto/challenge/FaceChallengeDto.java
+++ b/src/main/java/ongjong/namanmoo/dto/challenge/FaceChallengeDto.java
@@ -1,0 +1,31 @@
+package ongjong.namanmoo.dto.challenge;
+
+import lombok.Data;
+import ongjong.namanmoo.domain.answer.Answer;
+import ongjong.namanmoo.domain.challenge.Challenge;
+import ongjong.namanmoo.dto.answer.AnswerDto;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+public class FaceChallengeDto {
+
+    private String challengeTitle;
+    private String challengeNumber;
+    private Long challengeDate;
+    private boolean isComplete;
+    private List<AnswerDto> answerList;
+
+    public FaceChallengeDto(Challenge challenge, boolean isComplete, Long timeStamp , List<Answer> answers) {
+        this.challengeTitle = challenge.getChallengeTitle();
+        this.challengeNumber = challenge.getChallengeNum().toString();
+        this.challengeDate = timeStamp; // Use actual challenge date if available
+        this.isComplete = isComplete;
+        this.answerList = answers.stream()
+                .map(AnswerDto::new)
+                .collect(Collectors.toList());
+    }
+
+    private List<AnswerDto> answerDto;
+}

--- a/src/main/java/ongjong/namanmoo/dto/member/MemberInfoDto.java
+++ b/src/main/java/ongjong/namanmoo/dto/member/MemberInfoDto.java
@@ -13,7 +13,7 @@ public class MemberInfoDto {
     private final String name;
     private final String nickname;
     private final String role;
-    private final String memberImage;
+    private final String userImg;
 
 
     public MemberInfoDto(Member member) {
@@ -21,7 +21,6 @@ public class MemberInfoDto {
         this.name = member.getName();
         this.nickname = member.getNickname();
         this.role = member.getRole();
-        this.memberImage = member.getMemberImage();
-
+        this.userImg = member.getMemberImage();
     }
 }

--- a/src/main/java/ongjong/namanmoo/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/ongjong/namanmoo/global/exception/handler/GlobalExceptionHandler.java
@@ -4,8 +4,6 @@ import lombok.extern.slf4j.Slf4j;
 import ongjong.namanmoo.response.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.ErrorResponse;
-import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -47,3 +45,4 @@ public class GlobalExceptionHandler {
         return new ApiResponse<>("400", "File Size Exceed", null);
     }
 }
+

--- a/src/main/java/ongjong/namanmoo/service/AnswerService.java
+++ b/src/main/java/ongjong/namanmoo/service/AnswerService.java
@@ -137,6 +137,19 @@ public class AnswerService {
         return answerRepository.findByChallenge(challenge);
     }
 
+    // 가족 구성원들의 답변 유무 검사
+    @Transactional(readOnly = true)
+    public boolean isAnyAnswerComplete(Challenge challenge, Family family) {
+        List<Member> members = family.getMembers();
+        for (Member member : members) {
+            Optional<Answer> answer = answerRepository.findByChallengeAndMember(challenge, member);
+            if (answer.isPresent() && answer.get().getAnswerContent() != null) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     @Transactional(readOnly = true)
     public Lucky findCurrentLucky(Long familyId) {       // 현재 진행중인 lucky id 조회
         List<Lucky> luckies = luckyRepository.findByFamilyFamilyId(familyId);
@@ -147,7 +160,6 @@ public class AnswerService {
         }
         return null;
     }
-
 
     public Answer modifyAnswer(Long challengeId, String answerContent) throws Exception{        // 로그인한 맴버가 수정한 답변을 저장한다.
         Member member = memberRepository.findByLoginId(SecurityUtil.getLoginLoginId())
@@ -190,7 +202,6 @@ public class AnswerService {
     public boolean checkUserResponse(Member member, String createDate) {
         return answerRepository.existsByMemberAndCreateDateAndAnswerContentIsNotNull(member, createDate);
     }
-
 
     @Transactional
     public void offBalloon(Long challengeDate) throws Exception {

--- a/src/main/java/ongjong/namanmoo/service/FamilyService.java
+++ b/src/main/java/ongjong/namanmoo/service/FamilyService.java
@@ -106,7 +106,6 @@ public class FamilyService {
             throw new IllegalStateException("User already belongs to a family");
         }
 
-
         Family family = familyRepository.findById(familyId)
                 .orElseThrow(() -> new IllegalArgumentException("Family not found with id: " + familyId));
 

--- a/src/main/java/ongjong/namanmoo/service/FamilyService.java
+++ b/src/main/java/ongjong/namanmoo/service/FamilyService.java
@@ -62,7 +62,6 @@ public class FamilyService {
         return family;
     }
 
-
     // 내 가족 정보 확인
     public List<FamilyMemberDto> getFamilyMembersInfo() {
         String currentLoginId = SecurityUtil.getLoginLoginId();
@@ -91,8 +90,6 @@ public class FamilyService {
 
         return new FamilyInviteResponse(family.getFamilyName(), family.getFamilyId().toString(), memberDtos);
     }
-
-
 
     // 가족에 멤버 추가
     @Transactional


### PR DESCRIPTION
## 진행사항
- [x] 인생네컷 결과 저장
- [x] 인생네컷 결과 조회

## 특이사항
- [x] 인생네컷 챌린지 진행 후 `같은 4장의 사진 묶음`이 챌린지에 참여한 `각 멤버`에게 반환 됨
        따라서 답변이 존재하지 않는 멤버가 있을 수 있음 (이는 곧 챌린지 참여 여부(개인 기여도)와도 연결 됨)
- [x] 인생네컷 챌린지 진행 후 각 멤버에게 반환된  4장의 사진 묶음을 JSON 형식으로 저장
- [x] 멤버가 인생네컷 결과 조회 시, 해당 멤버의 가족 구성원들의 답변을 순회하며 하나를 반환하여 결과 조회
- [ ] 추후, ERD 수정 시 구현 변경 필요