### PR TITLE
[TSK-39] 인생네컷 사진 동시성 제어 및 DTO 변경

### DIFF
--- a/src/main/java/ongjong/namanmoo/controller/ChallengeController.java
+++ b/src/main/java/ongjong/namanmoo/controller/ChallengeController.java
@@ -194,16 +194,11 @@ public class ChallengeController {
     @GetMapping("/face")
     public ApiResponse<Object> getFaceChallenge(
             @RequestParam("challengeId") Long challengeId) throws Exception {
-
-        // 챌린지 조회
-        Challenge challenge = challengeService.findChallengeById(challengeId);
-        if (challenge == null) {
-            return new ApiResponse<>("404", "Challenge not found for the provided challengeId", null);
+        ApiResponse<Challenge> challengeResponse = validateChallenge(challengeId, ChallengeType.FACETIME);
+        if (!challengeResponse.getStatus().equals("200")) {
+            return new ApiResponse<>(challengeResponse.getStatus(), challengeResponse.getMessage(), null);
         }
-        // 챌린지 유형에 맞게 접근하도록 추가 : 챌린지ID로 가져온 챌린지가 Mapping된 챌린지 유0형에 맞지 않으면 오류 반환
-        if (!challenge.getChallengeType().equals(ChallengeType.FACETIME)) {
-            return new ApiResponse<>("400", "Invalid challenge type for the provided challengeId", null);
-        }
+        Challenge challenge = challengeResponse.getData();
 
         // 가족 초대 코드 조회 (멤버를 통해 가족 정보를 가져온 후 초대 코드 획득)
         Member member = memberService.findMemberByLoginId();
@@ -230,13 +225,14 @@ public class ChallengeController {
             @RequestParam("challengeId") Long challengeId,
             @RequestPart("answer") MultipartFile answerFile) throws Exception {
 
-        Challenge challenge = challengeService.findChallengeById(challengeId);
-        // 챌린지 유형에 맞게 접근하도록 추가 : 챌린지ID로 가져온 챌린지가 Mapping된 챌린지 유0형에 맞지 않으면 오류 반환
-        if (!challenge.getChallengeType().equals(ChallengeType.FACETIME)) {
-            return new ApiResponse<>("400", "Invalid challenge type for the provided challengeId", null);
+        ApiResponse<Challenge> challengeResponse = validateChallenge(challengeId, ChallengeType.FACETIME);
+        if (!challengeResponse.getStatus().equals("200")) {
+            return new ApiResponse<>(challengeResponse.getStatus(), challengeResponse.getMessage(), null);
         }
-        if (answerFile == null || answerFile.isEmpty()) {
-            return new ApiResponse<>("400", "Answer file is missing", null);
+        Challenge challenge = challengeResponse.getData();
+        ApiResponse<Void> fileResponse = validateFile(answerFile);
+        if (!fileResponse.getStatus().equals("200")) {
+            return new ApiResponse<>(fileResponse.getStatus(), fileResponse.getMessage(), null);
         }
         Member member = memberService.findMemberByLoginId();
         Family family = member.getFamily();
@@ -276,14 +272,11 @@ public class ChallengeController {
     public ApiResponse<Map<Integer, List<String>>> getFaceTimeAnswer(
             @RequestParam("challengeId") Long challengeId) throws Exception {
 
-        Challenge challenge = challengeService.findChallengeById(challengeId);
-        if (challenge == null) {
-            return new ApiResponse<>("404", "Challenge not found for the provided challengeId", null);
+        ApiResponse<Challenge> challengeResponse = validateChallenge(challengeId, ChallengeType.FACETIME);
+        if (!challengeResponse.getStatus().equals("200")) {
+            return new ApiResponse<>(challengeResponse.getStatus(), challengeResponse.getMessage(), null);
         }
-        // 챌린지 유형에 맞게 접근하도록 추가 : 챌린지ID로 가져온 챌린지가 Mapping된 챌린지 유0형에 맞지 않으면 오류 반환
-        if (!challenge.getChallengeType().equals(ChallengeType.FACETIME)) {
-            return new ApiResponse<>("400", "Invalid challenge type for the provided challengeId", null);
-        }
+        Challenge challenge = challengeResponse.getData();
 
         Member member = memberService.findMemberByLoginId();
         Family family = member.getFamily();
@@ -353,10 +346,12 @@ public class ChallengeController {
 
     // 챌린지 검증 헬퍼 메서드
     private ApiResponse<Challenge> validateChallenge(Long challengeId, ChallengeType... validTypes) {
+        // 챌린지 조회
         Challenge challenge = challengeService.findChallengeById(challengeId);
         if (challenge == null) {
             return new ApiResponse<>("404", "Challenge with provided challengeId not found", null);
         }
+        // 챌린지 유형에 맞게 접근하도록 추가 : 챌린지ID로 가져온 챌린지가 Mapping된 챌린지 유형에 맞지 않으면 오류 반환
         if (!Arrays.asList(validTypes).contains(challenge.getChallengeType())) {
             return new ApiResponse<>("400", "Invalid challenge type for the provided challengeId", null);
         }

--- a/src/main/java/ongjong/namanmoo/controller/RecapController.java
+++ b/src/main/java/ongjong/namanmoo/controller/RecapController.java
@@ -57,9 +57,8 @@ public class RecapController {
     // recap 화상통화
     @GetMapping("/face")
     public ApiResponse<MemberFacetimeDto> getFacetime(@RequestParam("luckyId") Long luckyId) throws Exception {
-        List<String> answerList = answerService.getFacetimeAnswerList(luckyId);
-        MemberFacetimeDto facetimeAnswerList = new MemberFacetimeDto(answerList);
-        return new ApiResponse<>("200", "Ranking retrieved successfully", facetimeAnswerList);
+        MemberFacetimeDto answerList = answerService.getFacetimeAnswerList(luckyId);
+        return new ApiResponse<>("200", "facetime retrieved successfully", answerList);
     }
 
     // 리캡 컨텐츠 조회 - 통계
@@ -87,7 +86,7 @@ public class RecapController {
         fastestAnsweredData.put("challengeNumber", fastestAnsweredChallenge != null ? fastestAnsweredChallenge.getChallengeNum() : "");
         fastestAnsweredData.put("challengeTitle", fastestAnsweredChallenge != null ? fastestAnsweredChallenge.getChallengeTitle() : "");
 
-        return new ApiResponse<>("200", "retrieved successfully", Arrays.asList(mostViewedData, fastestAnsweredData));
+        return new ApiResponse<>("200", "statistics retrieved successfully", Arrays.asList(mostViewedData, fastestAnsweredData));
     }
 
     // recap 과거 사진

--- a/src/main/java/ongjong/namanmoo/domain/answer/Answer.java
+++ b/src/main/java/ongjong/namanmoo/domain/answer/Answer.java
@@ -7,7 +7,6 @@ import lombok.Setter;
 import ongjong.namanmoo.domain.Member;
 import ongjong.namanmoo.domain.challenge.Challenge;
 
-
 @Entity
 @Getter @Setter
 @RequiredArgsConstructor

--- a/src/main/java/ongjong/namanmoo/dto/recap/MemberFacetimeDto.java
+++ b/src/main/java/ongjong/namanmoo/dto/recap/MemberFacetimeDto.java
@@ -6,9 +6,11 @@ import java.util.List;
 
 @Data
 public class MemberFacetimeDto {
+    private long challengeDate;
     private List<String> video;
 
-    public MemberFacetimeDto(List<String> facetimeAnswerList){
-        this.video = facetimeAnswerList;
+    public MemberFacetimeDto(long challengeDate, List<String> video){
+        this.challengeDate = challengeDate;
+        this.video = video;
     }
 }

--- a/src/main/java/ongjong/namanmoo/service/AnswerService.java
+++ b/src/main/java/ongjong/namanmoo/service/AnswerService.java
@@ -5,10 +5,7 @@ import ongjong.namanmoo.domain.Member;
 import ongjong.namanmoo.domain.answer.Answer;
 import ongjong.namanmoo.domain.challenge.Challenge;
 import ongjong.namanmoo.dto.challenge.ChallengeDetailsDto;
-import ongjong.namanmoo.dto.recap.MemberDto;
-import ongjong.namanmoo.dto.recap.MemberPhotosAnswerDto;
-import ongjong.namanmoo.dto.recap.MemberYouthAnswerDto;
-import ongjong.namanmoo.dto.recap.MemberAppreciationDto;
+import ongjong.namanmoo.dto.recap.*;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -54,7 +51,7 @@ public interface AnswerService {
     MemberPhotosAnswerDto getPhotoByMember(List<Member> members) throws Exception;
 
     // facetime에 대한 answerList를 반환
-    List<String> getFacetimeAnswerList(Long luckyId) throws Exception ;
+    MemberFacetimeDto getFacetimeAnswerList(Long luckyId) throws Exception ;
 
     // 챌린지 상세조회 중복요소 매핑
     ChallengeDetailsDto getChallengeDetails(Challenge challenge, Member member) throws Exception;

--- a/src/main/java/ongjong/namanmoo/service/ChallengeServiceImpl.java
+++ b/src/main/java/ongjong/namanmoo/service/ChallengeServiceImpl.java
@@ -159,7 +159,7 @@ public class ChallengeServiceImpl implements ChallengeService {
         if(challenges.size() == 1){
             return challenges.get(0);       // 오늘의 챌린지리스트 사이즈가 1이라면 첫번째 챌린지 반환
         }
-        else if(challenges.size() == 2) {    // 오늘의 챌린지리스트 사이즈가 2일 경우
+        else if(challenges.size() == 2) {    // 오늘의 챌린지리스트 사이즈가 2일 경우 -> GROUP 챌린지
             Challenge challenge1 = challenges.get(0);
             Challenge challenge2 = challenges.get(1);
             if (challenge1.getChallengeType() == ChallengeType.GROUP_PARENT) {
@@ -176,9 +176,9 @@ public class ChallengeServiceImpl implements ChallengeService {
                 }
             }
         }
-        else if(challenges.size() == 4){
+        else if(challenges.size() == 4){    // 오늘의 챌린지리스트 사이즈가 4일 경우 -> VOICE 챌린지
             List<Member> memberList = memberRepository.findByFamilyFamilyId(member.getFamily().getFamilyId());
-            for(int i = 0; i < memberList.size(); i++){
+            for(int i = 0; i < memberList.size(); i++) {
                 if(memberList.get(i) == member){
                     return challenges.get(i%4);
                 }

--- a/src/main/java/ongjong/namanmoo/service/ChallengeServiceImpl.java
+++ b/src/main/java/ongjong/namanmoo/service/ChallengeServiceImpl.java
@@ -410,6 +410,7 @@ public class ChallengeServiceImpl implements ChallengeService {
         return fastestChallenge;
     }
 
+    // 챌린지에 달린 답변 중, 가장 늦게 달린 답변 시간을 계산
     @Override
     public long calculateLatestResponseTime(Lucky lucky, Challenge challenge) throws Exception {
         long latestTime = Long.MIN_VALUE; // 해당 챌린지의 가장 늦은 응답시간을 저장할 변수

--- a/src/main/java/ongjong/namanmoo/service/DateUtil.java
+++ b/src/main/java/ongjong/namanmoo/service/DateUtil.java
@@ -1,4 +1,5 @@
 package ongjong.namanmoo.service;
+
 import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.Timestamp;
@@ -10,7 +11,6 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
-
 
 public class DateUtil {
 

--- a/src/main/java/ongjong/namanmoo/service/ImageMerger.java
+++ b/src/main/java/ongjong/namanmoo/service/ImageMerger.java
@@ -34,9 +34,9 @@ public class ImageMerger {
         BufferedImage mergedImage = new BufferedImage(finalWidth, finalHeight, BufferedImage.TYPE_INT_ARGB);
         Graphics2D g = mergedImage.createGraphics();
 
-        // 배경을 흰색으로 설정 (투명 배경을 원하면 이 부분을 제거)
-        g.setColor(Color.WHITE);
-        g.fillRect(0, 0, finalWidth, finalHeight);
+//        // 배경을 흰색으로 설정 (투명 배경을 원하면 이 부분을 제거)
+//        g.setColor(Color.WHITE);
+//        g.fillRect(0, 0, finalWidth, finalHeight);
 
         // 이미지 병합 및 중앙 정렬 (여유 공간 포함)
         for (int i = 0; i < size; i++) {

--- a/src/main/java/ongjong/namanmoo/service/SharedFileService.java
+++ b/src/main/java/ongjong/namanmoo/service/SharedFileService.java
@@ -155,6 +155,9 @@ public class SharedFileService {
                     })
                     .collect(Collectors.toList());
 
+            // 이미지 리스트를 무작위로 섞기
+            Collections.shuffle(images);
+
             // 빈 공간을 투명하게 채워 4개가 되도록 처리
             while (images.size() < 4) {
                 BufferedImage emptyImage = new BufferedImage(100, 100, BufferedImage.TYPE_INT_ARGB); // 너비와 높이를 100으로 설정하여 빈 이미지를 추가
@@ -180,7 +183,6 @@ public class SharedFileService {
             sharedFileRepository.save(mergedFile); // 데이터베이스에 새 SharedFile 저장
         }
     }
-
 
     // 병합된 이미지를 S3에 업로드하는 메서드
     public String uploadMergedImageToS3(BufferedImage mergedImage, String bucketName, String fileObjKeyName) throws IOException {


### PR DESCRIPTION
## 진행사항
- [x] 여러 스레드가 동시에 같은 리소스에 접근하지 않도록 동기화 메커니즘을 도입
- [x] 일정 시간이 지나도 이미지가 모두 업로드되지 않으면, 오류를 반환
- [x] 화상 챌린지 응답에 챌린지 날자 추가

## 특이사항
- [x] 동기화 제어: 싱글턴 객체에 대한 synchronized 키워드를 사용하여 여러 스레드에서 이미지를 업로드하고 병합하는 작업이 동시에 진행되는 것을 방지
- [x] 타임아웃: 웨이팅 루프가 무한히 실행되는 것을 방지하기 위해 최대 시간 한도(MAX_WAIT_TIME)를 설정
- [x] 재시도 간격: Thread.sleep(SLEEP_INTERVAL)를 사용하여 CPU 자원을 과도하게 사용하는 것을 방지하고, 이미지가 모두 업로드될 때까지 대기

- [x] 이미지를 그룹화하고, 각 그룹의 이미지가 4개 이상일 때만 병합하도록 변경
