### PR TITLE
[TSK-55] 챌린지 상세조회 변경 및 음성 챌린지 순서 변경

### DIFF
--- a/src/main/java/ongjong/namanmoo/controller/ChallengeController.java
+++ b/src/main/java/ongjong/namanmoo/controller/ChallengeController.java
@@ -463,9 +463,9 @@ public class ChallengeController {
             case VOICE1:
                 return "우리";
             case VOICE2:
-                return "많이";
-            case VOICE3:
                 return "행복하자";
+            case VOICE3:
+                return "많이";
             case VOICE4:
                 return "사랑해";
             default:

--- a/src/main/java/ongjong/namanmoo/controller/ChallengeController.java
+++ b/src/main/java/ongjong/namanmoo/controller/ChallengeController.java
@@ -136,9 +136,9 @@ public class ChallengeController {
         NormalChallengeDto normalChallengeDto = new NormalChallengeDto(challenge, details.isComplete(), details.getChallengeDate(), details.getAnswers());
 
         // 챌린지 조회 시 조회수 증가
-        Lucky currentLucky = luckyService.findCurrentLucky(member.getFamily().getFamilyId());
-        if (currentLucky != null){
-            luckyService.increaseChallengeViews(currentLucky.getLuckyId(), challenge.getChallengeNum());
+        Lucky matchedLucky = luckyService.findMatchingLucky(challengeId, member);
+        if (matchedLucky != null && matchedLucky.isRunning()){
+            luckyService.increaseChallengeViews(matchedLucky.getLuckyId(), challenge.getChallengeNum());
         }
 
         return new ApiResponse<>("200", "Normal challenge found successfully", normalChallengeDto);
@@ -174,9 +174,9 @@ public class ChallengeController {
         List<Answer> allAnswers = answerService.findAnswersByChallenges(challenge, member);     // 특정 그룹 챌린지에 매핑된 answer list 찾기
 
         // 챌린지 조회 시 조회수 증가
-        Lucky currentLucky = luckyService.findCurrentLucky(member.getFamily().getFamilyId());
-        if (currentLucky != null){
-            luckyService.increaseChallengeViews(currentLucky.getLuckyId(), challenge.getChallengeNum());
+        Lucky matchedLucky = luckyService.findMatchingLucky(challengeId, member);
+        if (matchedLucky != null && matchedLucky.isRunning()){
+            luckyService.increaseChallengeViews(matchedLucky.getLuckyId(), challenge.getChallengeNum());
         }
 
         GroupChallengeDto groupChallengeDto = challengeService.filterChallengesByMemberRole(challenge, challengeDate, isComplete, allAnswers);
@@ -213,10 +213,11 @@ public class ChallengeController {
         List<Answer> allAnswers = answerService.findAnswersByChallenges(challenge, member);     // 특정 사진 챌린지에 매핑된 answer list 찾기
 
         // 챌린지 조회 시 조회수 증가
-        Lucky currentLucky = luckyService.findCurrentLucky(member.getFamily().getFamilyId());
-        if (currentLucky != null){
-            luckyService.increaseChallengeViews(currentLucky.getLuckyId(), challenge.getChallengeNum());
+        Lucky matchedLucky = luckyService.findMatchingLucky(challengeId, member);
+        if (matchedLucky != null && matchedLucky.isRunning()){
+            luckyService.increaseChallengeViews(matchedLucky.getLuckyId(), challenge.getChallengeNum());
         }
+
         PhotoChallengeDto photoChallengeDto = new PhotoChallengeDto(challenge, isComplete, challengeDate, allAnswers);
         return new ApiResponse<>("200", "Photo Challenge found successfully", photoChallengeDto);
     }
@@ -345,13 +346,15 @@ public class ChallengeController {
             return new ApiResponse<>("404", "Family not found for the current member", null);
         }
 
-        Lucky currentLucky = luckyService.findCurrentLucky(member.getFamily().getFamilyId());
-        if (currentLucky != null){
-            luckyService.increaseChallengeViews(currentLucky.getLuckyId(), challenge.getChallengeNum());
-            // 응답 데이터 생성
+        // 챌린지 조회 시 조회수 증가
+        Lucky matchedLucky = luckyService.findMatchingLucky(challengeId, member);
+        if (matchedLucky != null && matchedLucky.isRunning()){
+            luckyService.increaseChallengeViews(matchedLucky.getLuckyId(), challenge.getChallengeNum());
         }
-        Lucky lucky = luckyService.findMatchingLucky(challengeId,member);
-        Map<Integer, List<String>> results = sharedFileService.getFaceChallengeResults(challenge.getChallengeNum(), lucky.getLuckyId());
+
+        assert matchedLucky != null;
+        Map<Integer, List<String>> results = sharedFileService.getFaceChallengeResults(challenge.getChallengeNum(), matchedLucky.getLuckyId());
+
 
         return new ApiResponse<>("200", "FaceTime Challenge results found successfully", results);
     }
@@ -371,9 +374,9 @@ public class ChallengeController {
         List<Answer> allAnswers = answerService.findAnswersByChallenges(challenge, member);     // 특정 음성 챌린지에 매핑된 answer list 찾기
 
         // 챌린지 조회 시 조회수 증가
-        Lucky currentLucky = luckyService.findCurrentLucky(member.getFamily().getFamilyId());
-        if (currentLucky != null){
-            luckyService.increaseChallengeViews(currentLucky.getLuckyId(), challenge.getChallengeNum());
+        Lucky matchedLucky = luckyService.findMatchingLucky(challengeId, member);
+        if (matchedLucky != null && matchedLucky.isRunning()){
+            luckyService.increaseChallengeViews(matchedLucky.getLuckyId(), challenge.getChallengeNum());
         }
 
         VoiceChallengeDto voiceChallengeDto = new VoiceChallengeDto(challenge, isComplete, challengeDate, allAnswers);

--- a/src/main/java/ongjong/namanmoo/service/ChallengeDataInit.java
+++ b/src/main/java/ongjong/namanmoo/service/ChallengeDataInit.java
@@ -40,8 +40,8 @@ public class ChallengeDataInit {
         challenges.add(createChallenge(13, "나의 어렸을 때 장래희망은 ◯◯였다.", ChallengeType.NORMAL));
         challenges.add(createChallenge(14, "가족과 함께한 휴가나 여행 사진을 공유해 주세요.", ChallengeType.PHOTO));
         challenges.add(createChallenge(15, "도전! 한 소절!/우리 지금 만나, 당장 만나/우리 지금 만나-리쌍", ChallengeType.VOICE1));
-        challenges.add(createChallenge(15, "도전! 한 소절!/너무나 많이 사랑한 죄/사랑앓이-FT아일랜드", ChallengeType.VOICE2));
-        challenges.add(createChallenge(15, "도전! 한 소절!/행복하자 우리 행복하자 아프지 말고/양화대교-자이언티", ChallengeType.VOICE3));
+        challenges.add(createChallenge(15, "도전! 한 소절!/행복하자 우리 행복하자 아프지 말고/양화대교-자이언티", ChallengeType.VOICE2));
+        challenges.add(createChallenge(15, "도전! 한 소절!/너무나 많이 사랑한 죄/사랑앓이-FT아일랜드", ChallengeType.VOICE3));
         challenges.add(createChallenge(15, "도전! 한 소절!/난 너를 사랑해 이 세상은 너뿐이야/붉은 노을-빅뱅", ChallengeType.VOICE4));
         challenges.add(createChallenge(16, "어렸을 때 가장 좋아했던 놀이 또는 게임은 무엇인가요?", ChallengeType.NORMAL));
         challenges.add(createChallenge(17, "가족과 가장 닮은 점, 혹은 닮고 싶은 점이 있나요?", ChallengeType.NORMAL));
@@ -76,8 +76,8 @@ public class ChallengeDataInit {
         challenges.add(createChallenge(43, "나의 어렸을 때 장래희망은 ◯◯였다.", ChallengeType.NORMAL));
         challenges.add(createChallenge(44, "가족과 함께한 휴가나 여행 사진을 공유해 주세요.", ChallengeType.PHOTO));
         challenges.add(createChallenge(45, "도전! 한 소절!/우리 지금 만나, 당장 만나/우리 지금 만나-리쌍", ChallengeType.VOICE1));
-        challenges.add(createChallenge(45, "도전! 한 소절!/너무나 많이 사랑한 죄/사랑앓이-FT아일랜드", ChallengeType.VOICE2));
-        challenges.add(createChallenge(45, "도전! 한 소절!/행복하자 우리 행복하자 아프지 말고/양화대교-자이언티", ChallengeType.VOICE3));
+        challenges.add(createChallenge(45, "도전! 한 소절!/행복하자 우리 행복하자 아프지 말고/양화대교-자이언티", ChallengeType.VOICE2));
+        challenges.add(createChallenge(45, "도전! 한 소절!/너무나 많이 사랑한 죄/사랑앓이-FT아일랜드", ChallengeType.VOICE3));
         challenges.add(createChallenge(45, "도전! 한 소절!/난 너를 사랑해 이 세상은 너뿐이야/붉은 노을-빅뱅", ChallengeType.VOICE4));
         challenges.add(createChallenge(46, "어렸을 때 가장 좋아했던 놀이 또는 게임은 무엇인가요?", ChallengeType.NORMAL));
         challenges.add(createChallenge(47, "가족과 가장 닮은 점, 혹은 닮고 싶은 점이 있나요?", ChallengeType.NORMAL));
@@ -112,8 +112,8 @@ public class ChallengeDataInit {
         challenges.add(createChallenge(73, "나의 어렸을 때 장래희망은 ◯◯였다.", ChallengeType.NORMAL));
         challenges.add(createChallenge(74, "가족과 함께한 휴가나 여행 사진을 공유해 주세요.", ChallengeType.PHOTO));
         challenges.add(createChallenge(75, "도전! 한 소절!/우리 지금 만나, 당장 만나/우리 지금 만나-리쌍", ChallengeType.VOICE1));
-        challenges.add(createChallenge(75, "도전! 한 소절!/너무나 많이 사랑한 죄/사랑앓이-FT아일랜드", ChallengeType.VOICE2));
-        challenges.add(createChallenge(75, "도전! 한 소절!/행복하자 우리 행복하자 아프지 말고/양화대교-자이언티", ChallengeType.VOICE3));
+        challenges.add(createChallenge(75, "도전! 한 소절!/행복하자 우리 행복하자 아프지 말고/양화대교-자이언티", ChallengeType.VOICE2));
+        challenges.add(createChallenge(75, "도전! 한 소절!/너무나 많이 사랑한 죄/사랑앓이-FT아일랜드", ChallengeType.VOICE3));
         challenges.add(createChallenge(75, "도전! 한 소절!/난 너를 사랑해 이 세상은 너뿐이야/붉은 노을-빅뱅", ChallengeType.VOICE4));
         challenges.add(createChallenge(76, "어렸을 때 가장 좋아했던 놀이 또는 게임은 무엇인가요?", ChallengeType.NORMAL));
         challenges.add(createChallenge(77, "가족과 가장 닮은 점, 혹은 닮고 싶은 점이 있나요?", ChallengeType.NORMAL));
@@ -148,8 +148,8 @@ public class ChallengeDataInit {
         challenges.add(createChallenge(103, "나의 어렸을 때 장래희망은 ◯◯였다.", ChallengeType.NORMAL));
         challenges.add(createChallenge(104, "가족과 함께한 휴가나 여행 사진을 공유해 주세요.", ChallengeType.PHOTO));
         challenges.add(createChallenge(105, "도전! 한 소절!/우리 지금 만나, 당장 만나/우리 지금 만나-리쌍", ChallengeType.VOICE1));
-        challenges.add(createChallenge(105, "도전! 한 소절!/너무나 많이 사랑한 죄/사랑앓이-FT아일랜드", ChallengeType.VOICE2));
-        challenges.add(createChallenge(105, "도전! 한 소절!/행복하자 우리 행복하자 아프지 말고/양화대교-자이언티", ChallengeType.VOICE3));
+        challenges.add(createChallenge(105, "도전! 한 소절!/행복하자 우리 행복하자 아프지 말고/양화대교-자이언티", ChallengeType.VOICE2));
+        challenges.add(createChallenge(105, "도전! 한 소절!/너무나 많이 사랑한 죄/사랑앓이-FT아일랜드", ChallengeType.VOICE3));
         challenges.add(createChallenge(105, "도전! 한 소절!/난 너를 사랑해 이 세상은 너뿐이야/붉은 노을-빅뱅", ChallengeType.VOICE4));
         challenges.add(createChallenge(106, "어렸을 때 가장 좋아했던 놀이 또는 게임은 무엇인가요?", ChallengeType.NORMAL));
         challenges.add(createChallenge(107, "가족과 가장 닮은 점, 혹은 닮고 싶은 점이 있나요?", ChallengeType.NORMAL));


### PR DESCRIPTION
## 진행사항
- [x] 조회수 올리는 로직이 현재 lucky에 대해 작용했는데, 해당 challengeNum에 대한 lucky를 찾고 running status가 false면 조회수가 안오르도록 수정
- [x] 음성 챌린지 순서 변경 

## 특이사항
- [x] 챌린지 상세 조회 시, 조회수 올리는 로직이 현재 lucky에 대해 작용했음. 현재 lucky가 해당 challengeId를 가지고 있지 않으면 문제 발생 → 위와 같이 해결
