### PR TITLE
[TSK-55] 사진 병합 로직 개선

### DIFF
--- a/src/main/java/ongjong/namanmoo/controller/ChallengeController.java
+++ b/src/main/java/ongjong/namanmoo/controller/ChallengeController.java
@@ -318,7 +318,7 @@ public class ChallengeController {
         } else if (answerFile.getContentType().startsWith("video/")) {
             // 비디오 업로드 동기 처리
             try {
-                String uploadedUrl = awsS3Service.uploadOriginalFile(answerFile);
+                String uploadedUrl = awsS3Service.uploadOriginalFile(answerFile, member.getMemberId());
                 answerService.modifyAnswer(challengeId, uploadedUrl);
 
                 // 병합 작업 필요 여부 확인 및 비동기 예약

--- a/src/main/java/ongjong/namanmoo/controller/ChallengeController.java
+++ b/src/main/java/ongjong/namanmoo/controller/ChallengeController.java
@@ -302,8 +302,13 @@ public class ChallengeController {
             // 이미지 업로드 동기 처리
             try {
                 Map<String, String> response = sharedFileService.uploadImageFile(challenge, answerFile, FileType.IMAGE);
-                // 병합 작업을 비동기적으로 예약
-                sharedFileService.scheduleMergeImages(challenge.getChallengeNum(), lucky);
+
+                // 병합 작업 필요 여부 확인 및 비동기 예약
+                boolean mergeNeeded = sharedFileService.checkIfMergeNeeded(challenge.getChallengeNum(), lucky);
+                if (mergeNeeded) {
+                    sharedFileService.scheduleMergeImages(challenge.getChallengeNum(), lucky);
+                }
+
                 return new ApiResponse<>("200", response.get("message"), response);
             } catch (Exception e) {
                 log.error("Image upload failed", e);
@@ -315,8 +320,13 @@ public class ChallengeController {
             try {
                 String uploadedUrl = awsS3Service.uploadOriginalFile(answerFile);
                 answerService.modifyAnswer(challengeId, uploadedUrl);
-                // 병합 작업을 비동기적으로 예약
-                sharedFileService.scheduleMergeImages(challenge.getChallengeNum(), lucky);
+
+                // 병합 작업 필요 여부 확인 및 비동기 예약
+                boolean mergeNeeded = sharedFileService.checkIfMergeNeeded(challenge.getChallengeNum(), lucky);
+                if (mergeNeeded) {
+                    sharedFileService.scheduleMergeImages(challenge.getChallengeNum(), lucky);
+                }
+
                 return new ApiResponse<>("200", "Video uploaded successfully", Map.of("url", uploadedUrl));
             } catch (Exception e) {
                 log.error("Video upload failed", e);

--- a/src/main/java/ongjong/namanmoo/controller/ChallengeController.java
+++ b/src/main/java/ongjong/namanmoo/controller/ChallengeController.java
@@ -365,12 +365,15 @@ public class ChallengeController {
 
         Map<Integer, List<String>> results = sharedFileService.getFaceChallengeResults(challenge.getChallengeNum(), matchedLucky.getLuckyId());
 
-        // 병합 이미지가 하나도 없는지 확인
-        boolean areMergedImagesPresent = results.values().stream().anyMatch(list -> !list.isEmpty());
+        // 필요한 모든 그룹 (cut_1, cut_2, cut_3, cut_4)에 대해 병합된 이미지가 있는지 확인
+        List<String> requiredCuts = Arrays.asList("1", "2", "3", "4");
+        List<String> missingCuts = requiredCuts.stream()
+                .filter(cut -> !results.containsKey(Integer.parseInt(cut)) || results.get(Integer.parseInt(cut)).isEmpty())
+                .collect(Collectors.toList());
 
-        if (!areMergedImagesPresent) {
-            // 병합된 이미지가 하나도 없다면, 다시 병합 작업을 예약
-            sharedFileService.scheduleMergeImages(challenge.getChallengeNum(), matchedLucky);
+        // 병합되지 않은 그룹에 대해 병합 작업을 예약
+        for (String missingCut : missingCuts) {
+            sharedFileService.scheduleMergeImagesForGroup(challenge.getChallengeNum(), matchedLucky, missingCut);
         }
 
         return new ApiResponse<>("200", "FaceTime Challenge results found successfully", results);

--- a/src/main/java/ongjong/namanmoo/controller/ChallengeController.java
+++ b/src/main/java/ongjong/namanmoo/controller/ChallengeController.java
@@ -365,15 +365,22 @@ public class ChallengeController {
 
         Map<Integer, List<String>> results = sharedFileService.getFaceChallengeResults(challenge.getChallengeNum(), matchedLucky.getLuckyId());
 
-        // 필요한 모든 그룹 (cut_1, cut_2, cut_3, cut_4)에 대해 병합된 이미지가 있는지 확인
-        List<String> requiredCuts = Arrays.asList("1", "2", "3", "4");
-        List<String> missingCuts = requiredCuts.stream()
-                .filter(cut -> !results.containsKey(Integer.parseInt(cut)) || results.get(Integer.parseInt(cut)).isEmpty())
-                .collect(Collectors.toList());
+        // 병합된 이미지가 4개 미만인지 확인
+        long mergedImagesCount = results.values().stream()
+                .flatMap(List::stream)
+                .count();
 
-        // 병합되지 않은 그룹에 대해 병합 작업을 예약
-        for (String missingCut : missingCuts) {
-            sharedFileService.scheduleMergeImagesForGroup(challenge.getChallengeNum(), matchedLucky, missingCut);
+        if (mergedImagesCount < 4) {
+            // 필요한 모든 그룹 (cut_1, cut_2, cut_3, cut_4)에 대해 병합된 이미지가 있는지 확인
+            List<String> requiredCuts = Arrays.asList("1", "2", "3", "4");
+            List<String> missingCuts = requiredCuts.stream()
+                    .filter(cut -> !results.containsKey(Integer.parseInt(cut)) || results.get(Integer.parseInt(cut)).isEmpty())
+                    .toList();
+
+            // 병합되지 않은 그룹에 대해 병합 작업을 예약
+            for (String missingCut : missingCuts) {
+                sharedFileService.scheduleMergeImagesForGroup(challenge.getChallengeNum(), matchedLucky, missingCut);
+            }
         }
 
         return new ApiResponse<>("200", "FaceTime Challenge results found successfully", results);

--- a/src/main/java/ongjong/namanmoo/controller/ChallengeController.java
+++ b/src/main/java/ongjong/namanmoo/controller/ChallengeController.java
@@ -305,9 +305,9 @@ public class ChallengeController {
             try {
                 Map<String, String> response = sharedFileService.uploadImageFile(challenge, answerFile, FileType.IMAGE);
 
-                // 업로드된 파일이 어느 그룹인지 확인
-                String uploadedFileName = response.get("fileName");
-                Matcher matcher = Pattern.compile("screenshot_(\\d+)").matcher(uploadedFileName);
+                // 업로드된 파일의 URL에서 그룹 정보를 추출
+                String uploadedUrl = response.get("url");
+                Matcher matcher = Pattern.compile("screenshot_(\\d+)").matcher(uploadedUrl);
                 if (matcher.find()) {
                     String group = matcher.group(1);
 

--- a/src/main/java/ongjong/namanmoo/service/AwsS3Service.java
+++ b/src/main/java/ongjong/namanmoo/service/AwsS3Service.java
@@ -99,13 +99,13 @@ public class AwsS3Service {
      * @return 업로드된 파일의 URL
      * @throws IOException 파일 변환 또는 업로드 중 발생하는 예외
      */
-    public String uploadOriginalFile(MultipartFile multipartFile) throws IOException {
+    public String uploadOriginalFile(MultipartFile multipartFile, Long memberId) throws IOException {
         log.info("Converting MultipartFile to File...");
         File uploadFile = convertFile(multipartFile)
                 .orElseThrow(() -> new IllegalArgumentException("MultipartFile -> File convert fail"));
 
         String fileType = determineFileType(multipartFile);
-        String fileName = generateFileName(uploadFile, fileType);
+        String fileName = generateFileName(uploadFile, fileType, memberId);  // 멤버 ID 포함하여 파일 이름 생성
 
         log.info("Uploading file to S3: {}", fileName);
         String uploadFileUrl = uploadFileToS3(uploadFile, fileName);
@@ -220,6 +220,15 @@ public class AwsS3Service {
 
 //        return fileType + "/" + UUID.randomUUID() + "_" + formattedDate + "_" + uploadFile.getName();
         return fileType + "/" + formattedDate + "_" + uploadFile.getName();
+    }
+
+    // generateFileName 메소드에 멤버 ID 추가
+    private String generateFileName(File uploadFile, String fileType, Long memberId) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS")
+                .withZone(ZoneId.systemDefault());
+        String formattedDate = formatter.format(Instant.now());
+        // 멤버 ID를 파일 이름에 포함시킵니다.
+        return fileType + "/" + memberId + "_" + formattedDate + "_" + uploadFile.getName();
     }
 
     /**

--- a/src/main/java/ongjong/namanmoo/service/AwsS3Service.java
+++ b/src/main/java/ongjong/namanmoo/service/AwsS3Service.java
@@ -96,6 +96,7 @@ public class AwsS3Service {
      * MultipartFile을 S3에 업로드하고 업로드된 파일의 URL을 반환하는 메소드.
      *
      * @param multipartFile 업로드할 MultipartFile
+     * @param memberId 업로드한 member Id
      * @return 업로드된 파일의 URL
      * @throws IOException 파일 변환 또는 업로드 중 발생하는 예외
      */

--- a/src/main/java/ongjong/namanmoo/service/SharedFileService.java
+++ b/src/main/java/ongjong/namanmoo/service/SharedFileService.java
@@ -386,11 +386,14 @@ public class SharedFileService {
     // 병합 작업 필요 여부를 확인하는 메서드
     public boolean checkIfMergeNeededForGroup(int challengeNum, Lucky lucky, String group) {
         List<SharedFile> sharedFiles = sharedFileRepository.findByChallengeNumAndLucky(challengeNum, lucky);
-        List<SharedFile> groupFiles = sharedFiles.stream()
-                .filter(file -> file.getFileName().contains("screenshot_" + group))
-                .toList();
+        long groupFileCount = sharedFiles.stream()
+                .filter(file -> {
+                    Matcher matcher = Pattern.compile("screenshot_(\\d+)").matcher(file.getFileName());
+                    return matcher.find() && matcher.group(1).equals(group);
+                })
+                .count();
 
-        return groupFiles.size() >= 4;
+        return groupFileCount >= 4;
     }
 
     // 병합 작업을 비동기적으로 예약하는 메서드 (특정 그룹)

--- a/src/main/java/ongjong/namanmoo/service/SharedFileService.java
+++ b/src/main/java/ongjong/namanmoo/service/SharedFileService.java
@@ -422,7 +422,8 @@ public class SharedFileService {
     }
 
     // 병합이 필요한 경우 특정 그룹의 이미지를 병합하는 메서드
-    private void mergeImagesIfNeededForGroup(int challengeNum, Lucky lucky, String group) throws IOException {
+    @Transactional
+    public void mergeImagesIfNeededForGroup(int challengeNum, Lucky lucky, String group) throws IOException {
         List<SharedFile> sharedFiles;
 
         // 병합 작업 중에는 다른 작업이 접근하지 못하도록 lock 사용

--- a/src/main/java/ongjong/namanmoo/service/SharedFileService.java
+++ b/src/main/java/ongjong/namanmoo/service/SharedFileService.java
@@ -98,7 +98,7 @@ public class SharedFileService {
         try {
             // S3에 파일 업로드 및 URL 저장
 //            String uploadedUrl = awsS3Service.uploadFile(photo);
-            String uploadedUrl = awsS3Service.uploadOriginalFile(photo);
+            String uploadedUrl = awsS3Service.uploadOriginalFile(photo, member.getMemberId());
 //            String uploadedUrl = awsS3Service.uploadFileWithRetry(photo, 3);
 
             Optional<Lucky> optionalLucky = luckyRepository.findByFamilyFamilyIdAndRunningTrue(family.getFamilyId());


### PR DESCRIPTION
이미지 병합 여부를 동기적으로 확인, 병합은 비동기적으로 진행

## 진행사항
- [x] 이미지 병합을 특정 'screenshot_N' 그룹에 의해 병합 되도록 변경
- [x]  화상 챌린지 결과를 조회 시, 병합된 이미지의 개수가 4개 미만일 때만, 병합되지 않은 그룹에 대해 이미지 병합을 예약

## 특이사항
- [x]  이미지는 특정 'screenshot_N' 그룹에 의해 병합되며, 그룹당 이미지가 4개 이상 존재하는 경우에만 병합 과정이 진행
- [x]  FaceTime Challenge 결과를 조회할 때, 필요한 모든 그룹 (cut_1, cut_2, cut_3, cut_4)에 대해 병합된 이미지가 있는지 확인 후, 만약 병합된 이미지가 없는 그룹이 있다면, 해당 그룹에 대해 병합 작업을 다시 예약
- [x] 데이터베이스 갱신 작업에 Transactional 어노테이션 추가
- [x] 화상 챌린지 결과 조회 시, 병합이 안된 이미지가 있다면, 병합 작업이 완료될 때까지 대기 후 병합된 이미지 결과를 동일 요청에서 반환하도록 수정